### PR TITLE
feat (user-api) - 불필요한 함수 제거

### DIFF
--- a/src/main/java/com/nhnacademy/bookstoreuserapi/controller/GuestController.java
+++ b/src/main/java/com/nhnacademy/bookstoreuserapi/controller/GuestController.java
@@ -39,7 +39,7 @@ public class GuestController {
 
         guestService.deleteGuest(guestEmail);
 
-        return ResponseEntity.ok().body("성공적으로 삭제하였습니다.");
+        return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/{guestEmail}")

--- a/src/main/java/com/nhnacademy/bookstoreuserapi/repository/GuestRepository.java
+++ b/src/main/java/com/nhnacademy/bookstoreuserapi/repository/GuestRepository.java
@@ -2,17 +2,9 @@ package com.nhnacademy.bookstoreuserapi.repository;
 
 import com.nhnacademy.bookstoreuserapi.domain.entity.Guest;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-
 public interface GuestRepository extends JpaRepository<Guest, Long> {
 
     Guest findByGuestEmail(String guestEmail);
-
-    @Modifying(clearAutomatically = true)
-    @Query("update Guest g set g.guestPassword = :password, g.guestName = :guestName, g.guestPhoneNumber = :guestPhoneNumber," +
-            "g.guestAddress = :guestAddress where g.guestEmail = :guestEmail")
-    void updateGuest(String password, String guestName, String guestPhoneNumber, String guestAddress, String guestEmail);
 
     void deleteByGuestEmail(String guestEmail);
 }

--- a/src/main/java/com/nhnacademy/bookstoreuserapi/repository/UserRepository.java
+++ b/src/main/java/com/nhnacademy/bookstoreuserapi/repository/UserRepository.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 
 public interface UserRepository extends JpaRepository<User, String> {
 
-    @Query("select u from User u where u.userId = :userId")
     User findByUserId(String userId);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/GuestServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/GuestServiceImpl.java
@@ -84,12 +84,6 @@ public class GuestServiceImpl implements GuestService {
         guest.setGuestPhoneNumber(guestUpdateRequest.guestPhoneNumber());
         guest.setGuestAddress(guestUpdateRequest.guestAddress());
 
-        guestRepository.updateGuest(guest.getGuestPassword(),
-                                    guest.getGuestName(),
-                                    guest.getGuestPhoneNumber(),
-                                    guest.getGuestAddress(),
-                                    guestEmail);
-
         return new ResponseGuest(
                 guest.getGuestPassword(),
                 guest.getGuestName(),

--- a/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/PointServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/PointServiceImpl.java
@@ -58,7 +58,7 @@ public class PointServiceImpl implements PointService {
 
     @Override
     public Page<ResponsePoint> findAll(String userId, Pageable pageable) {
-        if (userRepository.findById(userId).isEmpty()) {
+        if (!userRepository.existsById(userId)) {
             throw new UserNotFoundException(userId);
         }
         return pointRepository.findPointByUserId(userId, pageable);

--- a/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/PointTypeServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/PointTypeServiceImpl.java
@@ -19,13 +19,13 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PointTypeServiceImpl implements PointTypeService {
 
     private final PointTypeRepository pointTypeRepository;
     private final UserGradeRepository userGradeRepository;
 
     @Override
-    @Transactional
     public void savePointType(PointTypeCreateRequest request) {
 
         PointType pointType = new PointType();
@@ -64,7 +64,6 @@ public class PointTypeServiceImpl implements PointTypeService {
     }
 
     @Override
-    @Transactional
     public void deletePointType(Long typeId) {
 
         if(!pointTypeRepository.existsById(typeId)) {
@@ -75,7 +74,6 @@ public class PointTypeServiceImpl implements PointTypeService {
     }
 
     @Override
-    @Transactional
     public ResponsePointType updateEarningPoint(Long point, Long typeId) {
 
         pointTypeRepository.updateEarningPoint(point, typeId);
@@ -94,7 +92,6 @@ public class PointTypeServiceImpl implements PointTypeService {
     }
 
     @Override
-    @Transactional
     public ResponsePointType updateEarningRate(int rate, Long typeId) {
 
         pointTypeRepository.updateEarningRate(rate, typeId);

--- a/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/ReviewServiceImpl.java
@@ -57,16 +57,15 @@ public class ReviewServiceImpl implements ReviewService {
         findReview.setReviewPhoto(review.reviewPhoto());
         findReview.setUpdatedAt(LocalDateTime.now());
 
-        Review updatedReview = reviewRepository.save(findReview);
         return new ResponseReview(
-                updatedReview.getReviewId(),
-                updatedReview.getEvaluationScore(),
-                updatedReview.getReviewContent(),
-                updatedReview.getReviewPhoto(),
-                updatedReview.getReviewedAt(),
-                updatedReview.getUpdatedAt(),
-                updatedReview.getUser().getUserId(),
-                updatedReview.getBookId()
+                findReview.getReviewId(),
+                findReview.getEvaluationScore(),
+                findReview.getReviewContent(),
+                findReview.getReviewPhoto(),
+                findReview.getReviewedAt(),
+                findReview.getUpdatedAt(),
+                findReview.getUser().getUserId(),
+                findReview.getBookId()
         );
     }
 

--- a/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreuserapi/service/impl/UserServiceImpl.java
@@ -17,7 +17,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import static com.nhnacademy.bookstoreuserapi.domain.entity.UserGrade.Grade.BASIC;
 
@@ -90,9 +89,7 @@ public class UserServiceImpl implements UserService {
         user.setUserEmail(request.userEmail());
         user.setUserBirth(request.userBirth());
 
-        User updateUser = userRepository.save(user);
-
-        return new ResponseUser(updateUser);
+        return new ResponseUser(user);
     }
 
     @Override

--- a/src/test/java/com/nhnacademy/bookstoreuserapi/controller/GuestControllerTest.java
+++ b/src/test/java/com/nhnacademy/bookstoreuserapi/controller/GuestControllerTest.java
@@ -125,7 +125,7 @@ class GuestControllerTest {
         String email = "guest@example.com";
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/guests/{guestEmail}", email))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
         Mockito.verify(guestService).deleteGuest(email);
     }

--- a/src/test/java/com/nhnacademy/bookstoreuserapi/repository/GuestRepositoryTest.java
+++ b/src/test/java/com/nhnacademy/bookstoreuserapi/repository/GuestRepositoryTest.java
@@ -2,6 +2,7 @@ package com.nhnacademy.bookstoreuserapi.repository;
 
 import com.nhnacademy.bookstoreuserapi.config.QuerydslConfig;
 import com.nhnacademy.bookstoreuserapi.domain.entity.Guest;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +22,9 @@ class GuestRepositoryTest {
 
     @Autowired
     private GuestRepository guestRepository;
+
+    @Autowired
+    EntityManager entityManager;
 
     @BeforeEach
     void setup() {
@@ -46,15 +50,16 @@ class GuestRepositoryTest {
     @Test
     @DisplayName("Guest 정보 수정")
     void testUpdateGuest() {
-        guestRepository.updateGuest(
-                "newPassword",
-                "새이름",
-                "010-1111-2222",
-                "신주소",
-                "test@example.com"
-        );
 
         Guest updated = guestRepository.findByGuestEmail("test@example.com");
+
+        updated.setGuestPassword("newPassword");
+        updated.setGuestName("새이름");
+        updated.setGuestPhoneNumber("010-1111-2222");
+        updated.setGuestAddress("신주소");
+
+        entityManager.flush();
+        entityManager.clear();
 
         assertThat(updated.getGuestPassword()).isEqualTo("newPassword");
         assertThat(updated.getGuestName()).isEqualTo("새이름");

--- a/src/test/java/com/nhnacademy/bookstoreuserapi/service/ReviewServiceTest.java
+++ b/src/test/java/com/nhnacademy/bookstoreuserapi/service/ReviewServiceTest.java
@@ -34,8 +34,7 @@ import java.util.Optional;
 class ReviewServiceTest {
     @Mock
     ReviewRepository reviewRepository;
-
-
+    
     @Mock
     UserRepository userRepository;
 
@@ -115,7 +114,6 @@ class ReviewServiceTest {
         existingReview.setReviewId(reviewId);
 
         Mockito.when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(existingReview));
-        Mockito.when(reviewRepository.save(Mockito.any(Review.class))).thenReturn(existingReview);
 
         reviewService.editReview(reviewId, new ReviewUpdateRequest(4, "Updated review", ""));
 
@@ -189,7 +187,7 @@ class ReviewServiceTest {
         Page<ResponseReview> result = reviewService.getReviewsByUserId("user123", pageable);
 
         Assertions.assertEquals(1, result.getTotalElements());
-        Assertions.assertEquals("user123", result.getContent().get(0).getUserId());
+        Assertions.assertEquals("user123", result.getContent().getFirst().getUserId());
         Mockito.verify(reviewRepository, Mockito.times(1)).findAllByUserId("user123", pageable);
     }
 
@@ -216,7 +214,7 @@ class ReviewServiceTest {
         Page<ResponseReview> result = reviewService.getReviewsByBookId(bookId, pageable);
 
         Assertions.assertEquals(1, result.getTotalElements());
-        Assertions.assertEquals(1L, result.getContent().get(0).getBookId()); // getter에 따라 수정
+        Assertions.assertEquals(1L, result.getContent().getFirst().getBookId()); // getter에 따라 수정
         Mockito.verify(reviewRepository, Mockito.times(1)).findAllByBookId(bookId, pageable);
 
     }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📝 PR 개요

- JPA에서는 영속성 컨텍스트 내에 있는 엔티티의 필드 값을 변경하면, 트랜잭션 커밋 시 자동으로 DB에 반영해주기 때문에
  update 작업 시 save 함수를 한번 더 사용할 필요가 없음 따라서 제거함

## 🔗 관련 이슈

- #79

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 코드 스타일 가이드 및 커밋 메시지 규칙을 준수했습니다.

## 🖼️ 변경 전/후 스크린샷 (UI 변경 시, 선택)

- 변경된 UI가 있다면 스크린샷을 첨부해 주세요.

## 💬 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 정보나 특이사항을 적어 주세요.
